### PR TITLE
Enabled passing extra parameters to find method

### DIFF
--- a/src/Rossedman/Teamwork/Traits/RestfulTrait.php
+++ b/src/Rossedman/Teamwork/Traits/RestfulTrait.php
@@ -13,9 +13,9 @@ trait RestfulTrait {
     /**
      * @return mixed
      */
-    public function find()
+    public function find(array $data = [])
     {
-        return $this->client->get("$this->endpoint/$this->id")->response();
+        return $this->client->get("$this->endpoint/$this->id", $data)->response();
     }
 
     /**


### PR DESCRIPTION
This enables calling `Teamwork::project($id)->find()` and passing in parameters found here:
https://developer.teamwork.com/projects/api-v3/ref/projects/get-projects-api-v3-projects-projectidjson#request-parameters

Example:
```PHP
Teamwork::project($id)->find([
  'includeProjectOwner' => 1,
  'includePeople' => 1,
  'includeArchivedProjects' => 1,
])
```